### PR TITLE
Use CommonJS label instead of browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## installation
 
-### browserify
+### CommonJS
 
 ```
 npm install d3moji


### PR DESCRIPTION
Hey! Nice lib ;) I would use "CommonJS" instead of "browserify", because it also works with webpack or other module loaders.. Moreover you could add an "AMD" example. I just saw that you also support that module format.
